### PR TITLE
Fixed the deletion of bullets and invader on collision

### DIFF
--- a/objects/bullet.js
+++ b/objects/bullet.js
@@ -38,6 +38,7 @@ export default class Bullet {
 			this.score.updateScore();
 			this.speed = -this.speed;
 			this.markedForDeletion = true;
+			this.invader.markedForDeletion = true;
 		}
 
 		if (detectCollision(this, this.tank)) {

--- a/objects/invader.js
+++ b/objects/invader.js
@@ -26,7 +26,7 @@ export default class Invader {
 
 		if (this.position.x <= 0 || this.position.x >= this.gameWidth - this.width) {
 			this.speed = -this.speed;
-			this.markedForDeletion = true;
+			// this.markedForDeletion = true;
 		}
 	}
 }

--- a/src/game.js
+++ b/src/game.js
@@ -24,7 +24,8 @@ export default class Game {
 
 	update(deltaTime) {
 		[...this.gameObjects, ...this.bullets].forEach(object => object.update(deltaTime));
-		[...this.gameObjects, ...this.bullets].filter(object => !object.markedForDeletion);
+		this.gameObjects = this.gameObjects.filter(object => !object.markedForDeletion);
+		this.bullets = this.bullets.filter(bullet => !bullet.markedForDeletion);
 	}
 
 	showObjects() {


### PR DESCRIPTION
The main issue was in the game.js file.  The filtered arrays need to be re-assigned so the next loop will only be updating/drawing the non-deleted game objects.

When a bullet hits an invader, we now mark it for deletion.

Also, there was a bug in invader.js.  The invader was being deleted after hitting a wall.  I commented that line out just in case there was a reason for it.  :+1: 